### PR TITLE
Fix links in guidelines

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -10,7 +10,7 @@ Examples are not:
 * Full app deployments, ready to use, with no explanation. These
   belong to [Helm charts](https://github.com/kubernetes/charts).
 * Simple toys to show how to use a Kubernetes feature. These belong in
-  the [user guide](../docs/user-guide/).
+  the [user guide](https://kubernetes.io/docs/home/).
 * Demos that follow a script to show a Kubernetes feature in
   action. Example: killing a node to demonstrate controller
   self-healing.
@@ -28,8 +28,8 @@ Examples are not:
   commands (TL;DR / quickstart), without cloning the repo (kubectl
   apply -f http://...).
 * Points to documentation of prerequisites.
-  * [Create a cluster](../docs/getting-started-guides/) (e.g., single-node docker).
-  * [Setup kubectl](../docs/user-guide/prereqs.md).
+  * [Create a cluster](https://github.com/kubernetes/community/tree/master/contributors/devel/local-cluster) (e.g., single-node docker).
+  * [Setup kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
   * etc.
 * Should specify which release of Kubernetes is required and any other
   prerequisites, such as DNS, a cloudprovider with PV provisioning, a
@@ -42,21 +42,21 @@ Examples are not:
 ### Throughout
 
 * Should point to documentation on first mention:
-  [kubectl](../docs/user-guide/kubectl-overview.md),
-  [pods](../docs/user-guide/pods.md),
-  [services](../docs/user-guide/services.md),
-  [deployments](../docs/user-guide/deployments.md),
-  [replication controllers](../docs/user-guide/replication-controller.md),
-  [jobs](../docs/user-guide/jobs.md),
-  [labels](../docs/user-guide/labels.md),
-  [persistent volumes](../docs/user-guide/persistent-volumes.md),
+  [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/),
+  [pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/),
+  [services](https://kubernetes.io/docs/concepts/services-networking/service/),
+  [deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+  [replication controllers](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/),
+  [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/),
+  [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/),
+  [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/),
   etc.
 * Most examples should be cloudprovider-independent (e.g., using PVCs, not PDs).
   * Other examples with cloudprovider-specific bits could be somewhere else.
 * Actually show the app working -- console output, and or screenshots.
   * Ascii animations and screencasts are recommended.
-* Follows [config best practices](../docs/user-guide/config-best-practices.md).
-* Shouldn't duplicate the [thorough walk-through](../docs/user-guide/#thorough-walkthrough).
+* Follows [config best practices](https://kubernetes.io/docs/concepts/configuration/overview/).
+* Shouldn't duplicate the [user guide](https://kubernetes.io/docs/home/).
 * Docker images are pre-built, and source is contained in a subfolder.
   * Source is the Dockerfile and any custom files needed beyond the
     upstream app being packaged.


### PR DESCRIPTION
It used relative links before migration. Now they need to be updated.