### PR TITLE
Remove unnecessary `initialized` annotation.

### DIFF
--- a/staging/storage/minio/README.md
+++ b/staging/storage/minio/README.md
@@ -247,8 +247,6 @@ spec:
   replicas: 4
   template:
     metadata:
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         app: minio
     spec:

--- a/staging/storage/minio/minio-distributed-statefulset.yaml
+++ b/staging/storage/minio/minio-distributed-statefulset.yaml
@@ -7,8 +7,6 @@ spec:
   replicas: 4
   template:
     metadata:
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         app: minio
     spec:


### PR DESCRIPTION
The `pod.alpha.kubernetes.io/initialized` annotation is deprecated and the default in StatefulSet is `true` so it is unnecessary.

ref https://github.com/kubernetes/kubernetes/issues/41605