### PR TITLE
Switch from annotations to storageClassName in minikube example

### DIFF
--- a/staging/storage/minio/README.md
+++ b/staging/storage/minio/README.md
@@ -61,8 +61,7 @@ kind: PersistentVolumeClaim
 metadata:
   # This name uniquely identifies the PVC. Will be used in deployment below.
   name: minio-pv-claim
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: anything
+  storageClassName: standard
   labels:
     app: minio-storage-claim
 spec:
@@ -277,11 +276,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: data
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - ReadWriteOnce
+      storageClassName: standard
       resources:
         requests:
           storage: 10Gi

--- a/staging/storage/minio/minio-distributed-statefulset.yaml
+++ b/staging/storage/minio/minio-distributed-statefulset.yaml
@@ -37,11 +37,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: data
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - ReadWriteOnce
+      storageClassName: standard
       resources:
         requests:
           storage: 10Gi

--- a/staging/storage/minio/minio-standalone-pvc.yaml
+++ b/staging/storage/minio/minio-standalone-pvc.yaml
@@ -3,14 +3,13 @@ kind: PersistentVolumeClaim
 metadata:
   # This name uniquely identifies the PVC. Will be used in deployment below.
   name: minio-pv-claim
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: anything
   labels:
     app: minio-storage-claim
 spec:
   # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
   accessModes:
     - ReadWriteOnce
+  storageClassName: standard
   resources:
     # This is the request for storage. Should be available in the cluster.
     requests:


### PR DESCRIPTION
I was running through the minikube example and note that it uses the deprecated `volume.alpha.kubernetes.io/storage-class: anything` annotation instead of the newer `storageClassName: standard`

This PR just switches to `storageClassName: standard`