### PR TITLE
Fix broken include code path on wordpress/README

### DIFF
--- a/mysql-wordpress-pd/README.md
+++ b/mysql-wordpress-pd/README.md
@@ -62,7 +62,7 @@ A `hostPath` mounts a file or directory from the host node’s filesystem into y
 
        kubectl create -f local-volumes.yaml
 
-{% include code.html language="yaml" file="local-volumes.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/local-volumes.yaml" %}
+{% include code.html language="yaml" file="mysql-wordpress-persistent-volume/local-volumes.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/local-volumes.yaml" %}
 
 {:start="3"} 
 3. Run the following command to verify that two 20GiB PersistentVolumes are available:
@@ -102,7 +102,7 @@ A [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) is an obje
 
 The following manifest describes a single-instance MySQL Deployment. The MySQL container mounts the PersistentVolume at /var/lib/mysql. The `MYSQL_ROOT_PASSWORD` environment variable sets the database password from the Secret. 
 
-{% include code.html language="yaml" file="mysql-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml" %}
+{% include code.html language="yaml" file="mysql-wordpress-persistent-volume/mysql-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml" %}
 
 1. Deploy MySQL from the `mysql-deployment.yaml` file:
 
@@ -124,7 +124,7 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL c
 
 The following manifest describes a single-instance WordPress Deployment and Service. It uses many of the same features like a PVC for persistent storage and a Secret for the password. But it also uses a different setting: `type: NodePort`. This setting exposes WordPress to traffic from outside of the cluster.
 
-{% include code.html language="yaml" file="mysql-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml" %}
+{% include code.html language="yaml" file="mysql-wordpress-persistent-volume/mysql-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml" %}
 
 1. Create a WordPress Service and Deployment from the `wordpress-deployment.yaml` file:
 


### PR DESCRIPTION
This stuff takes A LOT OF back and forth between this repo and docs repo to
figure out something that works right. I'll move tutorial content to the docs
repo ASAP.