### PR TITLE
guestbook: Move image build instructions out

### DIFF
--- a/guestbook/MAINTENANCE.md
+++ b/guestbook/MAINTENANCE.md
@@ -1,0 +1,23 @@
+## Building the Docker images
+
+```console
+$ docker build -t gcr.io/google-samples/gb-frontend:v5 php-redis
+
+$ docker build -t gcr.io/google-samples/gb-redisslave:v2 redis-slave
+```
+
+Building Multi-architecture docker images
+
+```console
+$ make -C php-redis
+
+$ make -C redis-slave
+```
+
+Push:
+
+```console
+$ make -C php-redis all-push
+
+$ make -C redis-slave all-push
+```

--- a/guestbook/README.md
+++ b/guestbook/README.md
@@ -40,30 +40,6 @@ Download the following configuration files:
 
 {% capture lessoncontent %}
 
-## Building the Docker images
-
-```console
-$ docker build -t gcr.io/google-samples/gb-frontend:v5 php-redis
-
-$ docker build -t gcr.io/google-samples/gb-redisslave:v2 redis-slave
-```
-
-Building Multi-architecture docker images
-
-```console
-$ make -C php-redis
-
-$ make -C redis-slave
-```
-
-Push:
-
-```console
-$ make -C php-redis all-push
-
-$ make -C redis-slave all-push
-```
-
 ## Start up the Redis Master
 
 The guestbook application uses Redis to store its data. It writes its data to a Redis master instance and reads data from multiple Redis slave instances.


### PR DESCRIPTION
This section does not belong to the README.md which gets rendered at
https://kubernetes.io/docs/tutorials/stateless-application/guestbook/.
Moving these instructions to MAINTENANCE.md.

My bad for missing this during the review.

I will merge this directly to unblock the import to the docs site. Let me know
if you have any objections later on.
/cc @sebgoa @mkumatag
