### PR TITLE
Fixed README with the correct results and added the role to redis master

### DIFF
--- a/staging/storage/redis/README.md
+++ b/staging/storage/redis/README.md
@@ -92,8 +92,8 @@ kubectl delete pods redis-master
 Now let's take a close look at what happens after this pod is deleted.  There are three things that happen:
 
   1. The redis replication controller notices that its desired state is 3 replicas, but there are currently only 2 replicas, and so it creates a new redis server to bring the replica count back up to 3
-  2. The redis-sentinel replication controller likewise notices the missing sentinel, and also creates a new sentinel.
-  3. The redis sentinels themselves, realize that the master has disappeared from the cluster, and begin the election procedure for selecting a new master.  They perform this election and selection, and chose one of the existing redis server replicas to be the new master.
+
+  2. The redis sentinels themselves, realize that the redis master has disappeared from the cluster, and begin the election procedure for selecting a new master.  They perform this election and selection, and chose one of the existing redis server replicas to be the new master.
 
 ### Conclusion
 
@@ -124,6 +124,7 @@ kubectl scale rc redis --replicas=3
 kubectl scale rc redis-sentinel --replicas=3
 
 # Delete the original master pod
+# Note: If you are running all the above commands consecutively including this one in a shell script, it may NOT work out. When you run the above commands, let the pods first come up, especially the redis-master pod. Else, the sentinel pods would never be able to know the master redis server and establish a connection with it. 
 kubectl delete pods redis-master
 ```
 

--- a/staging/storage/redis/redis-controller.yaml
+++ b/staging/storage/redis/redis-controller.yaml
@@ -16,12 +16,12 @@ spec:
       - name: redis
         image: gcr.io/google_containers/redis:v1
         ports:
-          - containerPort: 6379
+        - containerPort: 6379
         resources:
           limits:
             cpu: "0.1"
         volumeMounts:
-          - mountPath: /redis-master-data
-            name: data
+        - mountPath: /redis-master-data
+          name: data
       volumes:
         - name: data

--- a/staging/storage/redis/redis-controller.yaml
+++ b/staging/storage/redis/redis-controller.yaml
@@ -10,19 +10,18 @@ spec:
     metadata:
       labels:
         name: redis
+        role: master
     spec:
       containers:
       - name: redis
         image: gcr.io/google_containers/redis:v1
         ports:
-        - containerPort: 6379
+          - containerPort: 6379
         resources:
           limits:
             cpu: "0.1"
         volumeMounts:
-        - mountPath: /redis-master-data
-          name: data
+          - mountPath: /redis-master-data
+            name: data
       volumes:
         - name: data
-          emptyDir: {}
-


### PR DESCRIPTION
A couple of fixes in README.md. For instance, when you delete the redis-master pod , the sentinel pods do not decrease to 2. Infact, its just the reds server pods that loses its pod. 

Also, added a word of caution for the newbies and the impatient to not run all commands consecutively but rather wait for th redid-master pod to come up and then delete it.