### PR TITLE
fix(wordpress): Fix link and displayed document in section on wordpress

### DIFF
--- a/mysql-wordpress-pd/README.md
+++ b/mysql-wordpress-pd/README.md
@@ -124,7 +124,7 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL c
 
 The following manifest describes a single-instance WordPress Deployment and Service. It uses many of the same features like a PVC for persistent storage and a Secret for the password. But it also uses a different setting: `type: NodePort`. This setting exposes WordPress to traffic from outside of the cluster.
 
-{% include code.html language="yaml" file="mysql-wordpress-persistent-volume/mysql-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml" %}
+{% include code.html language="yaml" file="mysql-wordpress-persistent-volume/wordpress-deployment.yaml" ghlink="/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml" %}
 
 1. Create a WordPress Service and Deployment from the `wordpress-deployment.yaml` file:
 


### PR DESCRIPTION
Found a small bug on the kubernetes docs site, the displayed code was for mysql a second time instead of the wordpress deployment yaml. This fixes that. 
Will i have to run ` ./update-imported-tutorials.sh ` as stated here https://github.com/kubernetes/kubernetes.github.io/edit/master/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md after this gets merged or is there a CI/CD thing thatll handle that?
