### PR TITLE
Update privileged PSP to allow all capabilities

### DIFF
--- a/staging/podsecuritypolicy/rbac/README.md
+++ b/staging/podsecuritypolicy/rbac/README.md
@@ -53,6 +53,8 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
+  allowedCapabilities:
+  - '*'
   hostPID: true
   hostIPC: true
   hostNetwork: true

--- a/staging/podsecuritypolicy/rbac/policies.yaml
+++ b/staging/podsecuritypolicy/rbac/policies.yaml
@@ -14,6 +14,8 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
+  allowedCapabilities:
+  - '*'
   hostPID: true
   hostIPC: true
   hostNetwork: true


### PR DESCRIPTION
kubernetes/kubernetes#51337 adds support for using `*` as a value in the `allowedCapabilities` field. This PR updates examples to use a this feature for the "privileged" PSP.

PTAL @pweil-
CC @simo5