### PR TITLE
elasticsearch: Add Role and RoleBinding for RBAC

### DIFF
--- a/staging/elasticsearch/README.md
+++ b/staging/elasticsearch/README.md
@@ -21,6 +21,13 @@ kubectl create -f staging/elasticsearch/es-svc.yaml
 kubectl create -f staging/elasticsearch/es-rc.yaml
 ```
 
+The [io.fabric8:elasticsearch-cloud-kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) plugin requires limited access to the Kubernetes API in order to fetch the list of Elasticsearch endpoints.
+If your cluster has the RBAC authorization mode enabled, create the additional `Role` and `RoleBinding` with:
+
+```
+kubectl create -f staging/elasticsearch/rbac.yaml
+```
+
 Let's see if it worked:
 
 ```

--- a/staging/elasticsearch/rbac.yaml
+++ b/staging/elasticsearch/rbac.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: elasticsearch
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: elasticsearch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: elasticsearch
+subjects:
+- kind: ServiceAccount
+  name: elasticsearch
+  namespace: default


### PR DESCRIPTION
Adds example Role and RoleBinding needed by [io.fabric8:elasticsearch-cloud-kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes).

Fixes #105