### PR TITLE
Fix link for pod yaml in vSphere Volumes README

### DIFF
--- a/staging/volumes/vsphere/README.md
+++ b/staging/volumes/vsphere/README.md
@@ -578,12 +578,12 @@
             claimName: pvcsc-vsan
       ```
 
-      [Download example](vsphere-volume-pvcscpod.yaml?raw=true)
+      [Download example](vsphere-volume-pvcscvsanpod.yaml?raw=true)
 
       Creating the pod:
 
       ``` bash
-      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
+      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-pvcscvsanpod.yaml
       ```
 
       Verifying pod is created:

--- a/staging/volumes/vsphere/vsphere-volume-pvcscvsanpod.yaml
+++ b/staging/volumes/vsphere/vsphere-volume-pvcscvsanpod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvpod
+spec:
+  containers:
+  - name: test-container
+    image: gcr.io/google_containers/test-webserver
+    volumeMounts:
+    - name: test-volume
+      mountPath: /test
+  volumes:
+  - name: test-volume
+    persistentVolumeClaim:
+      claimName: pvcsc-vsan


### PR DESCRIPTION
This PR fixes the link in vSphere Volumes README file for pod yaml and also adds the yaml file.
Fixes https://github.com/vmware/kubernetes/issues/342

//cc @divyenpatel 
