### PR TITLE
update all Deployment API version to apps/v1 in k8s v1.9.0 and add ac…

### DIFF
--- a/cassandra/cassandra-statefulset.yaml
+++ b/cassandra/cassandra-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1" # for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+apiVersion: "apps/v1" # for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: StatefulSet
 metadata:
   name: cassandra

--- a/guestbook/all-in-one/frontend.yaml
+++ b/guestbook/all-in-one/frontend.yaml
@@ -15,11 +15,15 @@ spec:
     app: guestbook
     tier: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend
 spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   replicas: 3
   template:
     metadata:

--- a/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -15,11 +15,16 @@ spec:
     tier: backend
     role: master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-master
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
   replicas: 1
   template:
     metadata:
@@ -54,11 +59,16 @@ spec:
     tier: backend
     role: slave
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   replicas: 2
   template:
     metadata:
@@ -102,11 +112,15 @@ spec:
     app: guestbook
     tier: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend
 spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   replicas: 3
   template:
     metadata:

--- a/guestbook/all-in-one/redis-slave.yaml
+++ b/guestbook/all-in-one/redis-slave.yaml
@@ -14,11 +14,16 @@ spec:
     role: slave
     tier: backend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   replicas: 2
   template:
     metadata:

--- a/guestbook/frontend-deployment.yaml
+++ b/guestbook/frontend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend

--- a/guestbook/redis-master-deployment.yaml
+++ b/guestbook/redis-master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-master

--- a/guestbook/redis-slave-deployment.yaml
+++ b/guestbook/redis-slave-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave

--- a/mysql-wordpress-pd/mysql-deployment.yaml
+++ b/mysql-wordpress-pd/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress-mysql

--- a/mysql-wordpress-pd/wordpress-deployment.yaml
+++ b/mysql-wordpress-pd/wordpress-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress

--- a/staging/cockroachdb/cockroachdb-statefulset.yaml
+++ b/staging/cockroachdb/cockroachdb-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
       app: cockroachdb
   minAvailable: 67%
 ---
-apiVersion: apps/v1  # for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1  #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/staging/newrelic/README.md
+++ b/staging/newrelic/README.md
@@ -70,7 +70,7 @@ The DaemonSet definition instructs Kubernetes to place a newrelic sysmond agent 
 <!-- BEGIN MUNGE: EXAMPLE newrelic-daemonset.yaml -->
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: newrelic-agent
@@ -79,6 +79,9 @@ metadata:
     app: newrelic-agent
     version: v1
 spec:
+  selector:
+    matchLabels:
+      name: newrelic
   template:
     metadata:
       labels:

--- a/staging/newrelic/newrelic-daemonset.yaml
+++ b/staging/newrelic/newrelic-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: newrelic-agent

--- a/staging/openshift-origin/etcd-controller.yaml
+++ b/staging/openshift-origin/etcd-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: etcd

--- a/staging/openshift-origin/etcd-discovery-controller.yaml
+++ b/staging/openshift-origin/etcd-discovery-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: etcd-discovery

--- a/staging/openshift-origin/openshift-controller.yaml
+++ b/staging/openshift-origin/openshift-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   labels:

--- a/staging/storage/hazelcast/README.md
+++ b/staging/storage/hazelcast/README.md
@@ -72,13 +72,16 @@ Deployments will "adopt" existing pods that match their selector query, so let's
 <!-- BEGIN MUNGE: EXAMPLE hazelcast-controller.yaml -->
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: "apps/v1" # for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata: 
   name: hazelcast
   labels: 
     name: hazelcast
-spec: 
+spec:
+  selector:
+    matchLabels:
+      name: hazelcast
   template: 
     metadata: 
       labels: 

--- a/staging/storage/hazelcast/hazelcast-deployment.yaml
+++ b/staging/storage/hazelcast/hazelcast-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata: 
   name: hazelcast

--- a/staging/storage/minio/README.md
+++ b/staging/storage/minio/README.md
@@ -88,12 +88,15 @@ A deployment encapsulates replica sets and pods — so, if a pod goes down, 
 This is the deployment description.
 
 ```sh
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -237,7 +240,7 @@ A StatefulSet provides a deterministic name and a unique identity to each pod, m
 This is the Statefulset description.
 
 ```sh
-# for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+#  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/staging/storage/minio/minio-distributed-statefulset.yaml
+++ b/staging/storage/minio/minio-distributed-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: StatefulSet
 metadata:
   name: minio

--- a/staging/storage/minio/minio-standalone-deployment.yaml
+++ b/staging/storage/minio/minio-standalone-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:

--- a/staging/sysdig-cloud/sysdig-daemonset.yaml
+++ b/staging/sysdig-cloud/sysdig-daemonset.yaml
@@ -1,6 +1,6 @@
 #Use this sysdig.yaml when Daemon Sets are enabled on Kubernetes (minimum version 1.1.1). Otherwise use the RC method.
 
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1  #for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: sysdig-agent

--- a/staging/volumes/vsphere/README.md
+++ b/staging/volumes/vsphere/README.md
@@ -633,7 +633,7 @@ vSphere volumes can be consumed by Stateful Sets.
        selector:
          app: nginx
      ---
-     # for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+     #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
      apiVersion:apps/v1
      kind: StatefulSet
      metadata:

--- a/staging/volumes/vsphere/deployment.yaml
+++ b/staging/volumes/vsphere/deployment.yaml
@@ -1,8 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: deployment
 spec:
+  selector:
+    matchLabels:
+      app: redis
   replicas: 1
   template:
     metadata:

--- a/staging/volumes/vsphere/simple-statefulset.yaml
+++ b/staging/volumes/vsphere/simple-statefulset.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: StatefulSet
 metadata:
   name: web


### PR DESCRIPTION
update all Deployment API version to apps/v1 in k8s v1.9.0 and add accurate annotations for the old version of k8s how to use API version。

Signed-off-by: LinWengang <linwengang@chinacloud.com.cn>