### PR TITLE
Improve cassandra deployment

### DIFF
--- a/cassandra/cassandra-statefulset.yaml
+++ b/cassandra/cassandra-statefulset.yaml
@@ -15,9 +15,10 @@ spec:
       labels:
         app: cassandra
     spec:
+      terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: gcr.io/google-samples/cassandra:v12
+        image: gcr.io/google-samples/cassandra:v13
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -42,7 +43,10 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "PID=$(pidof java) && kill $PID && while ps -p $PID > /dev/null; do sleep 1; done"]
+              command: 
+              - /bin/sh
+              - -c
+              - nodetool drain
         env:
           - name: MAX_HEAP_SIZE
             value: 512M
@@ -56,8 +60,6 @@ spec:
             value: "DC1-K8Demo"
           - name: CASSANDRA_RACK
             value: "Rack1-K8Demo"
-          - name: CASSANDRA_AUTO_BOOTSTRAP
-            value: "false"
           - name: POD_IP
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This PR ports two fixes that "disappear" in the migration from `kubernetes/kubernetes`
- https://github.com/kubernetes/kubernetes/commit/c165e9084ff0710ec54095d69c86eb3594f2f0f9#diff-a21f09fe308ab1a86e11b8330930566b
- https://github.com/kubernetes/kubernetes/commit/82241e4c0d2f73b03d8d4bd0cfe73860fca62b06#diff-a21f09fe308ab1a86e11b8330930566b

Also removes the `CASSANDRA_AUTO_BOOTSTRAP` setting. I cannot found a PR that changed the default.

fixes #175