### PR TITLE
staging/podsecuritypolicy/rbac: use PSP from policy API group

### DIFF
--- a/staging/podsecuritypolicy/rbac/policies.yaml
+++ b/staging/podsecuritypolicy/rbac/policies.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
@@ -23,7 +23,7 @@ spec:
   - min: 1
     max: 65536
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted

--- a/staging/podsecuritypolicy/rbac/roles.yaml
+++ b/staging/podsecuritypolicy/rbac/roles.yaml
@@ -5,7 +5,7 @@ metadata:
   name: restricted-psp-user
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resources:
   - podsecuritypolicies
   resourceNames:
@@ -20,7 +20,7 @@ metadata:
   name: privileged-psp-user
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resources:
   - podsecuritypolicies
   resourceNames:


### PR DESCRIPTION
This PR updates PSP examples to use `policy/v1beta1` API group. This make them identical to what we already have in kubernetes `examples/` directory.

Related PRs in k8s repo: https://github.com/kubernetes/kubernetes/pull/54933 and https://github.com/kubernetes/kubernetes/pull/60145

PTAL @liggitt @tallclair 
CC @simo5