### PR TITLE
Fix PodSecurityPolicy Examples

### DIFF
--- a/staging/podsecuritypolicy/rbac/roles.yaml
+++ b/staging/podsecuritypolicy/rbac/roles.yaml
@@ -5,7 +5,7 @@ metadata:
   name: restricted-psp-user
 rules:
 - apiGroups:
-  - policy
+  - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
@@ -20,7 +20,7 @@ metadata:
   name: privileged-psp-user
 rules:
 - apiGroups:
-  - policy
+  - extensions
   resources:
   - podsecuritypolicies
   resourceNames:


### PR DESCRIPTION
I discovered that the PSP examples weren't working and it turned out to be a simple fix - PSP objects are under extensions/v1beta1 so the ClusterRole wasn't actually granting anything.