### PR TITLE
Add details on mounting existing Azure Managed Disks

### DIFF
--- a/staging/volumes/azure_disk/README.md
+++ b/staging/volumes/azure_disk/README.md
@@ -4,8 +4,9 @@ On Azure VM, create a Pod using the volume spec based on [azure](azure.yaml).
 
 In the pod, you need to provide the following information:
 
-- *diskName*:  (required) the name of the VHD blob object.
-- *diskURI*: (required) the URI of the vhd blob object.
+- *diskName*:  (required) the name of the VHD blob object OR the name of an Azure managed data disk if Kind is Managed.
+- *diskURI*: (required) the URI of the vhd blob object OR the resourceID of an Azure managed data disk if Kind is Managed.
+- *kind*: (optional) kind of disk. Must be one of Shared (multiple disks per storage account), Dedicated (single blob disk per storage account), or Managed (Azure managed data disk). Default is Shared.
 - *cachingMode*: (optional) disk caching mode. Must be one of None, ReadOnly, or ReadWrite. Default is None.
 - *fsType*:  (optional) the filesytem type to mount. Default is ext4.
 - *readOnly*: (optional) whether the filesystem is used as readOnly. Default is false.

--- a/staging/volumes/azure_disk/static-provisioning/managed-disk/pod-uses-existing-managed-disk.yaml
+++ b/staging/volumes/azure_disk/static-provisioning/managed-disk/pod-uses-existing-managed-disk.yaml
@@ -1,0 +1,24 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod-uses-managed-ssd-5g
+  labels:
+    name: storage
+spec:
+  containers:
+  - image: nginx
+    name: az-c-01
+    command:
+    - /bin/sh
+    - -c
+    - while true; do echo $(date) >> /mnt/managed/outfile; sleep 1; done
+    volumeMounts:
+    - name: managed01
+      mountPath: /mnt/managed
+  volumes:
+  - name: managed01
+    azureDisk:
+      kind: Managed
+      diskName: myDisk
+      diskURI: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/disks/<diskName>
+


### PR DESCRIPTION
This PR adds examples for how to use preexisting Managed Disks with Pods

The information was gathered from the following sources:
* [AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#azurediskvolumesource-v1-core)
* [validation.go](https://github.com/kubernetes/kubernetes/blob/ae1fc13aee81e66b9b74a5fb881ff3f90463ff4e/pkg/apis/core/validation/validation.go#L1291)
* [types.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L1365)
* [Volumes with Azure Disks](https://docs.microsoft.com/en-us/azure/aks/azure-disk-volume)
