### PR TITLE
Fix NFS tutorial README links

### DIFF
--- a/staging/volumes/nfs/README.md
+++ b/staging/volumes/nfs/README.md
@@ -24,16 +24,16 @@ Note, this example uses an NFS container that doesn't support NFSv4.
 ## Quickstart
 
 ```console
-$ kubectl create -f examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
-$ kubectl create -f examples/volumes/nfs/nfs-server-rc.yaml
-$ kubectl create -f examples/volumes/nfs/nfs-server-service.yaml
+$ kubectl create -f examples/staging/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-server-rc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-server-service.yaml
 # get the cluster IP of the server using the following command
 $ kubectl describe services nfs-server
 # use the NFS server IP to update nfs-pv.yaml and execute the following
-$ kubectl create -f examples/volumes/nfs/nfs-pv.yaml
-$ kubectl create -f examples/volumes/nfs/nfs-pvc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-pv.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-pvc.yaml
 # run a fake backend
-$ kubectl create -f examples/volumes/nfs/nfs-busybox-rc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-busybox-rc.yaml
 # get pod name from this command
 $ kubectl get pod -l name=nfs-busybox
 # use the pod name to check the test file

--- a/staging/volumes/nfs/README.md
+++ b/staging/volumes/nfs/README.md
@@ -60,12 +60,12 @@ Define [the NFS Service and Replication Controller](nfs-server-rc.yaml) and
 The NFS server exports an an auto-provisioned persistent volume backed by GCE PD:
 
 ```console
-$ kubectl create -f examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
+$ kubectl create -f examples/staging/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
 ```
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-server-rc.yaml
-$ kubectl create -f examples/volumes/nfs/nfs-server-service.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-server-rc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-server-service.yaml
 ```
 
 The directory contains dummy `index.html`. Wait until the pod is running
@@ -92,8 +92,8 @@ claim gives us an indirection that allow multiple pods to refer to the NFS
 server using a symbolic name rather than the hardcoded server address.
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-pv.yaml
-$ kubectl create -f examples/volumes/nfs/nfs-pvc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-pv.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-pvc.yaml
 ```
 
 ## Setup the fake backend
@@ -102,7 +102,7 @@ The [NFS busybox controller](nfs-busybox-rc.yaml) updates `index.html` on the
 NFS server every 10 seconds. Let's start that now:
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-busybox-rc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-busybox-rc.yaml
 ```
 
 Conveniently, it's also a `busybox` pod, so we can get an early check
@@ -132,14 +132,14 @@ volume and runs a simple web server on it.
 Define the pod:
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-web-rc.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-web-rc.yaml
 ```
 
 This creates two pods, each of which serve the `index.html` from above. We can
 then use a simple service to front it:
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-web-service.yaml
+$ kubectl create -f examples/staging/volumes/nfs/nfs-web-service.yaml
 ```
 
 We can then use the busybox container we launched before to check that `nginx`
@@ -162,5 +162,5 @@ nfs-busybox-w3s4t
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/volumes/nfs/README.md?pixel)]()
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/staging/volumes/nfs/README.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/staging/volumes/nfs/nfs-pv.yaml
+++ b/staging/volumes/nfs/nfs-pv.yaml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteMany
   nfs:
     # FIXME: use the right IP
-    server: 10.244.1.4
+    server: 10.35.240.4
     path: "/"

--- a/staging/volumes/nfs/nfs-pv.yaml
+++ b/staging/volumes/nfs/nfs-pv.yaml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteMany
   nfs:
     # FIXME: use the right IP
-    server: 10.35.240.4
+    server: 10.244.1.4
     path: "/"


### PR DESCRIPTION
The commands/links in the README for the NFS tutorial were stale since moving stuff to staging. 