### PR TITLE
change the order of objects' creation

### DIFF
--- a/staging/volumes/nfs/README.md
+++ b/staging/volumes/nfs/README.md
@@ -64,8 +64,8 @@ $ kubectl create -f examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
 ```
 
 ```console
-$ kubectl create -f examples/volumes/nfs/nfs-server-rc.yaml
 $ kubectl create -f examples/volumes/nfs/nfs-server-service.yaml
+$ kubectl create -f examples/volumes/nfs/nfs-server-rc.yaml
 ```
 
 The directory contains dummy `index.html`. Wait until the pod is running


### PR DESCRIPTION
Even though the ReplicationController object is not the recommended way to set up replication in the current version of Kubernetes (v1.9), following the configuration best practices present in the documentation of Kubernetes v1.6 (https://v1-6.docs.kubernetes.io/docs/concepts/configuration/overview/), "It’s typically best to create a service before corresponding replication controllers".