### PR TITLE
https-nginx: Correct tls.[crt|key] mount

### DIFF
--- a/staging/https-nginx/default.conf
+++ b/staging/https-nginx/default.conf
@@ -8,8 +8,8 @@ server {
         index index.html;
 
         server_name localhost;
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
+        ssl_certificate /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
 
         location / {
                 try_files $uri $uri/ =404;


### PR DESCRIPTION
Fixes #194.