### PR TITLE
Add a sample for using azureFile for PVs

### DIFF
--- a/staging/volumes/azure_file/README.md
+++ b/staging/volumes/azure_file/README.md
@@ -8,13 +8,13 @@ Note, as explained in [Azure File Storage for Linux](https://azure.microsoft.com
 
 ## Create a storage access secret
 
-Obtain an Microsoft Azure storage account and create a [secret](secret/azure-secret.yaml) that contains the base64 encoded Azure Storage account name and key. In the secret file, base64-encode Azure Storage account name and pair it with name `azurestorageaccountname`, and base64-encode Azure Storage access key and pair it with name `azurestorageaccountkey`.
-
-Alternatively, use `kubectl` directly to create the secret:
+Obtain an Microsoft Azure storage account and extract the storage account name (which you provided) and one of the storage account keys. You will then need to create a Kubernetes secret which holds both the account name and key. You can use `kubectl` directly to create the secret:
 
 ```console
 # kubectl create secret generic azure-secret --from-literal=azurestorageaccountname=<...> --from-literal=azurestorageaccountkey=<...>
 ```
+
+Alternatively, you can create a [secret](secret/azure-secret.yaml) that contains the base64 encoded Azure Storage account name and key. In the secret file, base64-encode Azure Storage account name and pair it with name `azurestorageaccountname`, and base64-encode Azure Storage access key and pair it with name `azurestorageaccountkey`. The advantage of this is that you can `kubectl apply -f` the secret file, whereas you need to delete a secret before you can create a new one using `kubectl create secret`.
 
 Based on the storage account name, and using the [`az` command line](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest), you can also extract the storage account key using the following command line, given that you are logged in using `az login` with a service principal which has access to the service account:
 

--- a/staging/volumes/azure_file/README.md
+++ b/staging/volumes/azure_file/README.md
@@ -6,15 +6,32 @@ Install *cifs-utils* on the Kubernetes host. For example, on Fedora based Linux
 
 Note, as explained in [Azure File Storage for Linux](https://azure.microsoft.com/en-us/documentation/articles/storage-how-to-use-files-linux/), the Linux hosts and the file share must be in the same Azure region.
 
-Obtain an Microsoft Azure storage account and create a [secret](secret/azure-secret.yaml) that contains the base64 encoded Azure Storage account name and key. In the secret file, base64-encode Azure Storage account name and pair it with name *azurestorageaccountname*, and base64-encode Azure Storage access key and pair it with name *azurestorageaccountkey*.
+## Create a storage access secret
+
+Obtain an Microsoft Azure storage account and create a [secret](secret/azure-secret.yaml) that contains the base64 encoded Azure Storage account name and key. In the secret file, base64-encode Azure Storage account name and pair it with name `azurestorageaccountname`, and base64-encode Azure Storage access key and pair it with name `azurestorageaccountkey`.
+
+Alternatively, use `kubectl` directly to create the secret:
+
+```console
+# kubectl create secret generic azure-secret --from-literal=azurestorageaccountname=<...> --from-literal=azurestorageaccountkey=<...>
+```
+
+Based on the storage account name, and using the [`az` command line](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest), you can also extract the storage account key using the following command line, given that you are logged in using `az login` with a service principal which has access to the service account:
+
+```console
+# export STORAGE_ACCOUNT_KEY=$(az storage account keys list -n <storage account name> -g <resource group> --query='[0].value' | tr -d '"')
+```
+
+## Pod creation
 
 Then create a Pod using the volume spec based on [azure](azure.yaml).
 
 In the pod, you need to provide the following information:
 
-- *secretName*:  the name of the secret that contains both Azure storage account name and key.
-- *shareName*: The share name to be used.
-- *readOnly*: Whether the filesystem is used as readOnly.
+- `secretName`:  the name of the secret that contains both Azure storage account name and key.
+- `shareName`: The share name to be used.
+- `readOnly`: Whether the filesystem is used as readOnly.
+- `secretNamespace`: (optional) The namespace in which the secret was created; `default` is used if not set
 
 Create the secret:
 
@@ -24,11 +41,22 @@ Create the secret:
 
 You should see the account name and key from `kubectl get secret`
 
+### Mount volume directly in Pod
+
 Then create the Pod:
 
 ```console
     # kubectl create -f examples/volumes/azure_file/azure.yaml
 ```
+
+### Mount volume via `pv` and `pvc`
+
+The same mechanism can also be used to mount the Azure File Storage using a Persistent Volume and a Persistent Volume Claim:
+
+* [Persistent Volume using `azureFile`](azure-pv.yaml)
+* [Persistent Volume Claim matching the Volume](azure-pvc.yaml)
+
+Correspondingly, you then mount the volume inside pods using the normal `persistentVolumeClaim` reference. This mechanism is used in the sample pod YAML [azure-2.yaml](azure-2.yaml).
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/volumes/azure_file/README.md?pixel)]()

--- a/staging/volumes/azure_file/azure-2.yaml
+++ b/staging/volumes/azure_file/azure-2.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+ name: azure-2
+spec:
+ containers:
+  - image: kubernetes/pause
+    name: azure-2
+    volumeMounts:
+      - name: azure
+        mountPath: /mnt/azure
+ volumes:
+  - name: azure
+    persistentVolumeClaim:
+      claimName: storage-sample

--- a/staging/volumes/azure_file/azure-2.yaml
+++ b/staging/volumes/azure_file/azure-2.yaml
@@ -12,4 +12,4 @@ spec:
  volumes:
   - name: azure
     persistentVolumeClaim:
-      claimName: storage-sample
+      claimName: sample-storage-claim

--- a/staging/volumes/azure_file/azure-pv.yaml
+++ b/staging/volumes/azure_file/azure-pv.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sample-storage
+  # The label is used for matching the exact claim
+  labels:
+    usage: sample-storage
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  azureFile:
+    # Replace with your secret name
+    secretName: azure-secret
+    # Replace with correct storage share name
+    shareName: k8stest
+    # In case the secret is stored in a different namespace
+    #shareNamespace: default
+    readOnly: false

--- a/staging/volumes/azure_file/azure-pvc.yaml
+++ b/staging/volumes/azure_file/azure-pvc.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: storage-sample
+  name: sample-storage-claim
   # Set this annotation to NOT let Kubernetes automatically create
   # a persistent volume for this volume claim.
   annotations:
@@ -15,4 +15,4 @@ spec:
   selector:
     # To make sure we match the claim with the exact volume, match the label
     matchLabels:
-      usage: storage-sample
+      usage: sample-storage

--- a/staging/volumes/azure_file/azure-pvc.yaml
+++ b/staging/volumes/azure_file/azure-pvc.yaml
@@ -1,0 +1,18 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: storage-sample
+  # Set this annotation to NOT let Kubernetes automatically create
+  # a persistent volume for this volume claim.
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    # To make sure we match the claim with the exact volume, match the label
+    matchLabels:
+      usage: storage-sample


### PR DESCRIPTION
The example for azureFile previously just had a sample of how to directly mount an Azure Files storage into a Pod. I thought it would be nice to also have an example which uses a persistent volume/persistent volume claim, which can be done in the same way. I also added how to get the storage account key via code (using the az command line), and how to create a secret using `kubectl` directly instead of via a `Secret` manifest (which is somewhat clunky).