### PR TITLE
Fix cloud-dns README links

### DIFF
--- a/staging/cluster-dns/README.md
+++ b/staging/cluster-dns/README.md
@@ -16,8 +16,8 @@ $ hack/dev-build-and-up.sh
 We'll see how cluster DNS works across multiple [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/), first we need to create two namespaces:
 
 ```sh
-$ kubectl create -f examples/cluster-dns/namespace-dev.yaml
-$ kubectl create -f examples/cluster-dns/namespace-prod.yaml
+$ kubectl create -f examples/staging/cluster-dns/namespace-dev.yaml
+$ kubectl create -f examples/staging/cluster-dns/namespace-prod.yaml
 ```
 
 Now list all namespaces:
@@ -42,11 +42,11 @@ $ kubectl config set-context prod --namespace=production --cluster=${CLUSTER_NAM
 
 ### Step Two: Create backend replication controller in each namespace
 
-Use the file [`examples/cluster-dns/dns-backend-rc.yaml`](dns-backend-rc.yaml) to create a backend server [replication controller](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) in each namespace.
+Use the file [`examples/staging/cluster-dns/dns-backend-rc.yaml`](dns-backend-rc.yaml) to create a backend server [replication controller](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) in each namespace.
 
 ```sh
 $ kubectl config use-context dev
-$ kubectl create -f examples/cluster-dns/dns-backend-rc.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-backend-rc.yaml
 ```
 
 Once that's up you can list the pod in the cluster:
@@ -61,7 +61,7 @@ Now repeat the above commands to create a replication controller in prod namespa
 
 ```sh
 $ kubectl config use-context prod
-$ kubectl create -f examples/cluster-dns/dns-backend-rc.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-backend-rc.yaml
 $ kubectl get rc
 CONTROLLER    CONTAINER(S)   IMAGE(S)              SELECTOR           REPLICAS
 dns-backend   dns-backend    ddysher/dns-backend   name=dns-backend   1
@@ -69,12 +69,12 @@ dns-backend   dns-backend    ddysher/dns-backend   name=dns-backend   1
 
 ### Step Three: Create backend service
 
-Use the file [`examples/cluster-dns/dns-backend-service.yaml`](dns-backend-service.yaml) to create
+Use the file [`examples/staging/cluster-dns/dns-backend-service.yaml`](dns-backend-service.yaml) to create
 a [service](https://kubernetes.io/docs/concepts/services-networking/service/) for the backend server.
 
 ```sh
 $ kubectl config use-context dev
-$ kubectl create -f examples/cluster-dns/dns-backend-service.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-backend-service.yaml
 ```
 
 Once that's up you can list the service in the cluster:
@@ -89,7 +89,7 @@ Again, repeat the same process for prod namespace:
 
 ```sh
 $ kubectl config use-context prod
-$ kubectl create -f examples/cluster-dns/dns-backend-service.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-backend-service.yaml
 $ kubectl get service dns-backend
 NAME         CLUSTER_IP       EXTERNAL_IP       PORT(S)                SELECTOR          AGE
 dns-backend  10.0.2.4         <none>            8000/TCP               name=dns-backend  1d
@@ -97,11 +97,11 @@ dns-backend  10.0.2.4         <none>            8000/TCP               name=dns-
 
 ### Step Four: Create client pod in one namespace
 
-Use the file [`examples/cluster-dns/dns-frontend-pod.yaml`](dns-frontend-pod.yaml) to create a client [pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/) in dev namespace. The client pod will make a connection to backend and exit. Specifically, it tries to connect to address `http://dns-backend.development.cluster.local:8000`.
+Use the file [`examples/staging/cluster-dns/dns-frontend-pod.yaml`](dns-frontend-pod.yaml) to create a client [pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/) in dev namespace. The client pod will make a connection to backend and exit. Specifically, it tries to connect to address `http://dns-backend.development.cluster.local:8000`.
 
 ```sh
 $ kubectl config use-context dev
-$ kubectl create -f examples/cluster-dns/dns-frontend-pod.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-frontend-pod.yaml
 ```
 
 Once that's up you can list the pod in the cluster:
@@ -128,7 +128,7 @@ If we switch to prod namespace with the same pod config, we'll see the same resu
 
 ```sh
 $ kubectl config use-context prod
-$ kubectl create -f examples/cluster-dns/dns-frontend-pod.yaml
+$ kubectl create -f examples/staging/cluster-dns/dns-frontend-pod.yaml
 $ kubectl logs dns-frontend
 2015-05-07T20:13:54.147664936Z 10.0.236.129
 2015-05-07T20:13:54.147721290Z Send request to: http://dns-backend.development.cluster.local:8000
@@ -148,8 +148,8 @@ For those of you who are impatient, here is the summary of the commands we ran i
 
 ```sh
 # create dev and prod namespaces
-kubectl create -f examples/cluster-dns/namespace-dev.yaml
-kubectl create -f examples/cluster-dns/namespace-prod.yaml
+kubectl create -f examples/staging/cluster-dns/namespace-dev.yaml
+kubectl create -f examples/staging/cluster-dns/namespace-prod.yaml
 
 # create two contexts
 CURRENT_CONTEXT=$(kubectl config view -o jsonpath='{.current-context}')
@@ -160,27 +160,27 @@ kubectl config set-context prod --namespace=production --cluster=${CLUSTER_NAME}
 
 # create two backend replication controllers
 kubectl config use-context dev
-kubectl create -f examples/cluster-dns/dns-backend-rc.yaml
+kubectl create -f examples/staging/cluster-dns/dns-backend-rc.yaml
 kubectl config use-context prod
-kubectl create -f examples/cluster-dns/dns-backend-rc.yaml
+kubectl create -f examples/staging/cluster-dns/dns-backend-rc.yaml
 
 # create backend services
 kubectl config use-context dev
-kubectl create -f examples/cluster-dns/dns-backend-service.yaml
+kubectl create -f examples/staging/cluster-dns/dns-backend-service.yaml
 kubectl config use-context prod
-kubectl create -f examples/cluster-dns/dns-backend-service.yaml
+kubectl create -f examples/staging/cluster-dns/dns-backend-service.yaml
 
 # create a pod in each namespace and get its output
 kubectl config use-context dev
-kubectl create -f examples/cluster-dns/dns-frontend-pod.yaml
+kubectl create -f examples/staging/cluster-dns/dns-frontend-pod.yaml
 kubectl logs dns-frontend
 
 kubectl config use-context prod
-kubectl create -f examples/cluster-dns/dns-frontend-pod.yaml
+kubectl create -f examples/staging/cluster-dns/dns-frontend-pod.yaml
 kubectl logs dns-frontend
 ```
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/cluster-dns/README.md?pixel)]()
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/staging/cluster-dns/README.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->


### PR DESCRIPTION
The links and paths used as argument in the `kubectl` command were outdated.