### PR TITLE
Creation of PSP by hack/local-up-cluster.sh is not as automatic as the README suggests.

### DIFF
--- a/staging/podsecuritypolicy/rbac/README.md
+++ b/staging/podsecuritypolicy/rbac/README.md
@@ -37,7 +37,23 @@ that RBAC will be enforced
 ## Creating the policies, roles, and bindings
 
 NOTE: If you are using `local-up-cluster.sh` you don't need to create these
-policies, roles, and bindings as they already have been created by the script.
+policies, roles, and bindings as they already have been created by the script,
+provided the Kubernetes repository contains `examples` symlink pointing to
+`staging` subdirectory of this repository checkout. For example, if you've
+checked out Kubernetes as
+
+```console
+$ git clone https://github.com/kubernetes/kubernetes
+```
+and this examples repository next to it as
+```console
+$ git clone https://github.com/kubernetes/examples
+```
+create symlink
+```console
+$ ( cd kubernetes && ln -s ../examples/staging examples )
+```
+
 
 ### Policies
 


### PR DESCRIPTION
Without the symlinks, `hack/local-up-cluster.sh` reports

```
Create podsecuritypolicy policies for RBAC.
error: the path "/home/test/kubernetes/examples/podsecuritypolicy/rbac/policies.yaml" does not exist
error: the path "/home/test/kubernetes/examples/podsecuritypolicy/rbac/roles.yaml" does not exist
error: the path "/home/test/kubernetes/examples/podsecuritypolicy/rbac/bindings.yaml" does not exist
```