### PR TITLE
guestbook : Remove explicit install for php-pear

### DIFF
--- a/guestbook/php-redis/Dockerfile
+++ b/guestbook/php-redis/Dockerfile
@@ -15,7 +15,6 @@
 FROM php:5-apache
 
 RUN apt-get update
-RUN apt-get install -y php-pear
 RUN pear channel-discover pear.nrk.io
 RUN pear install nrk/Predis
 


### PR DESCRIPTION
Looks like `pear` is installed by default and there is no separate package named `php-pear` anymore

Fixes #256