### PR TITLE
Build and push manifests for container images

### DIFF
--- a/guestbook/php-redis/Makefile
+++ b/guestbook/php-redis/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = v5
+TAG = v6
 REGISTRY = gcr.io/google-samples
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le
@@ -49,7 +49,9 @@ sub-push-%:
 all-container: $(addprefix sub-container-,$(ALL_ARCH))
 
 all-push: $(addprefix sub-push-,$(ALL_ARCH))
-
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do echo docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push ${IMAGE}:${TAG}
 
 container: .container-$(ARCH)
 .container-$(ARCH):
@@ -70,10 +72,7 @@ endif
 
 push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
-	gcloud docker -- push $(MULTI_ARCH_IMG):$(TAG)
-ifeq ($(ARCH), amd64)
-	gcloud docker -- push $(IMAGE):$(TAG)
-endif
+	docker push $(IMAGE):$(TAG)
 
 clean: $(addprefix sub-clean-,$(ALL_ARCH))
 	docker rmi -f $(IMAGE):$(TAG) || true

--- a/guestbook/redis-slave/Makefile
+++ b/guestbook/redis-slave/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = v2
+TAG = v3
 REGISTRY = gcr.io/google-samples
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le
@@ -47,6 +47,9 @@ sub-push-%:
 all-container: $(addprefix sub-container-,$(ALL_ARCH))
 
 all-push: $(addprefix sub-push-,$(ALL_ARCH))
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do echo docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push ${IMAGE}:${TAG}
 
 container: .container-$(ARCH)
 .container-$(ARCH):
@@ -65,10 +68,7 @@ endif
 
 push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
-	gcloud docker -- push $(MULTI_ARCH_IMG):$(TAG)
-ifeq ($(ARCH), amd64)
-	gcloud docker -- push $(IMAGE):$(TAG)
-endif
+	docker push $(IMAGE):$(TAG)
 
 clean: $(addprefix sub-clean-,$(ALL_ARCH))
 	docker rmi -f $(IMAGE):$(TAG) || true


### PR DESCRIPTION
We build and push images for various architectures, but are not
publishing a single manifest that can be used to look up the images.
test/images in main k/k repository and kube images in k/release already
publish manifests for all the image we need for e2e testing, so we
should do the same as the 2 images in this repository are part of the
conformance e2e test suite.

Bumping version numbers as well.

Change-Id: I5f87af9e5ad15da86b9e99bcb7a60a81870d0836