### PR TITLE
Use init-containers instead of sidecar model

### DIFF
--- a/staging/javaweb-tomcat-sidecar/javaweb-2.yaml
+++ b/staging/javaweb-tomcat-sidecar/javaweb-2.yaml
@@ -3,19 +3,17 @@ kind: Pod
 metadata:
   name: javaweb-2
 spec:
-  containers:
+  initContainers:
   - image: resouer/sample:v2
     name: war
-    lifecycle:
-      postStart:
-        exec:
-          command:
-            - "cp"
-            - "/sample.war"
-            - "/app"
+      command:
+        - "cp"
+        - "/sample.war"
+        - "/app"
     volumeMounts:
     - mountPath: /app
       name: app-volume
+  containers:
   - image: resouer/mytomcat:7.0
     name: tomcat
     command: ["sh","-c","/root/apache-tomcat-7.0.42-v2/bin/start.sh"]

--- a/staging/javaweb-tomcat-sidecar/javaweb.yaml
+++ b/staging/javaweb-tomcat-sidecar/javaweb.yaml
@@ -3,22 +3,22 @@ kind: Pod
 metadata:
   name: javaweb
 spec:
+  initContainers:
+    - image: resouer/sample:v1
+      name: war
+      volumeMounts:
+        - mountPath: /app
+          name: app-volume
   containers:
-  - image: resouer/sample:v1
-    name: war
-    volumeMounts:
-    - mountPath: /app
-      name: app-volume
-  - image: resouer/mytomcat:7.0
-    name: tomcat
-    command: ["sh","-c","/root/apache-tomcat-7.0.42-v2/bin/start.sh"]
-    volumeMounts:
-    - mountPath: /root/apache-tomcat-7.0.42-v2/webapps
-      name: app-volume
-    ports:
-    - containerPort: 8080
-      hostPort: 8001
+    - image: resouer/mytomcat:7.0
+      name: tomcat
+      command: ["sh", "-c", "/root/apache-tomcat-7.0.42-v2/bin/start.sh"]
+      volumeMounts:
+        - mountPath: /root/apache-tomcat-7.0.42-v2/webapps
+          name: app-volume
+      ports:
+        - containerPort: 8080
+          hostPort: 8001
   volumes:
-  - name: app-volume
-    emptyDir: {}
-
+    - name: app-volume
+      emptyDir: {}


### PR DESCRIPTION
Converted the example to use an [init-container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) instead of the sidecar model as the init-container is a bit cleaner & light-weight.  The container that exclusively copies a war file into place does not have to continue running after its job is done.  Therefore using an init-container allows the container with the war file to run, copy its payload into place & then terminate.

Also, using an init-container ensures that the copying of the payload _must_ complete _before_ the Tomcat container can start.  This removes the chance for a race condition (however unlikely) in which Tomcat starts before the war file is copied in place.