### PR TITLE
Update alpine linux version in Dockerfile

### DIFF
--- a/staging/storage/redis/image/Dockerfile
+++ b/staging/storage/redis/image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.4
+FROM alpine:3.8
 
 RUN apk add --no-cache redis sed bash
 


### PR DESCRIPTION
Alpine version 3.4 is EOL since 2018-05-01.
See https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

Signed-off-by: Oz N Tiram <oz.tiram@gmail.com>