### PR TITLE
Use new env vars to parameterize selenium nodes

### DIFF
--- a/staging/selenium/selenium-node-chrome-deployment.yaml
+++ b/staging/selenium/selenium-node-chrome-deployment.yaml
@@ -20,9 +20,9 @@ spec:
         ports:
           - containerPort: 5900
         env:
-          - name: HUB_PORT_4444_TCP_ADDR
+          - name: HUB_HOST
             value: "selenium-hub"
-          - name: HUB_PORT_4444_TCP_PORT
+          - name: HUB_PORT
             value: "4444"
         resources:
           limits:

--- a/staging/selenium/selenium-node-firefox-deployment.yaml
+++ b/staging/selenium/selenium-node-firefox-deployment.yaml
@@ -27,9 +27,9 @@ spec:
           - mountPath: /dev/shm
             name: dshm
         env:
-          - name: HUB_PORT_4444_TCP_ADDR
+          - name: HUB_HOST
             value: "selenium-hub"
-          - name: HUB_PORT_4444_TCP_PORT
+          - name: HUB_PORT
             value: "4444"
         resources:
           limits:


### PR DESCRIPTION
The new variable names got introduced about 10 months ago and it was
indicated that they will be used in the ling term instead of the older,
less descriptive variable names.