### PR TITLE
Updated selenium hub health probes to recommended endpoints

### DIFF
--- a/staging/selenium/selenium-hub-deployment.yaml
+++ b/staging/selenium/selenium-hub-deployment.yaml
@@ -25,13 +25,13 @@ spec:
             cpu: ".5"
         livenessProbe:
           httpGet:
-            path: /grid/console
+            path: /wd/hub/status
             port: 4444
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /grid/console
+            path: /wd/hub/status
             port: 4444
           initialDelaySeconds: 30
           timeoutSeconds: 5


### PR DESCRIPTION
Probing the hub on `/grid/console` might end up in constant restarts due to locks.
the recommended way is using `/wd/hub/status`.
Even the helm chart updated this
https://github.com/helm/charts/pull/7554
