### PR TITLE
Fixes python 3 support for cluster-dns images scripts

### DIFF
--- a/staging/cluster-dns/images/backend/server.py
+++ b/staging/cluster-dns/images/backend/server.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler,HTTPServer
 
 PORT_NUMBER = 8000
 
@@ -30,8 +30,8 @@ class HTTPHandler(BaseHTTPRequestHandler):
 try:
   # Create a web server and define the handler to manage the incoming request.
   server = HTTPServer(('', PORT_NUMBER), HTTPHandler)
-  print 'Started httpserver on port ' , PORT_NUMBER
+  print('Started httpserver on port ', PORT_NUMBER)
   server.serve_forever()
 except KeyboardInterrupt:
-  print '^C received, shutting down the web server'
+  print('^C received, shutting down the web server')
   server.socket.close()

--- a/staging/cluster-dns/images/frontend/client.py
+++ b/staging/cluster-dns/images/frontend/client.py
@@ -17,21 +17,25 @@
 import argparse
 import requests
 import socket
+import sys
 
-from urlparse import urlparse
+if sys.version_info[0] < 3:
+  from urlparse import urlparse
+else:
+  from urllib.parse import urlparse
 
 
 def CheckServiceAddress(address):
   hostname = urlparse(address).hostname
   service_address = socket.gethostbyname(hostname)
-  print service_address
+  print(service_address)
 
 
 def GetServerResponse(address):
-  print 'Send request to:', address
+  print('Send request to:', address)
   response = requests.get(address)
-  print response
-  print response.content
+  print(response)
+  print(response.content)
 
 
 def Main():


### PR DESCRIPTION
The cluster-dns images' scripts are only working with Python 2.

Considering that Python 2 support will be dropped in 2020, it
would be a good idea to transition towards Python 3 support.

This commit the cluster-dns Python scripts to work on both
Python versions.