### PR TITLE
cluster-dns: Writes bytes on response

### DIFF
--- a/staging/cluster-dns/images/backend/server.py
+++ b/staging/cluster-dns/images/backend/server.py
@@ -25,7 +25,7 @@ class HTTPHandler(BaseHTTPRequestHandler):
     self.send_response(200)
     self.send_header('Content-type','text/html')
     self.end_headers()
-    self.wfile.write("Hello World!")
+    self.wfile.write(b"Hello World!")
 
 try:
   # Create a web server and define the handler to manage the incoming request.


### PR DESCRIPTION
In Python3, strings are unicode, while in Python2 they're bytes. This causes an issue when writing the request response, since it expects bytes.