### PR TITLE
Update redis slave controller image to point to k8s.gcr.io

### DIFF
--- a/guestbook-go/redis-slave-controller.json
+++ b/guestbook-go/redis-slave-controller.json
@@ -25,7 +25,7 @@
             "containers":[
                {
                   "name":"redis-slave",
-                  "image":"kubernetes/redis-slave:v2",
+                  "image":"k8s.gcr.io/redis-slave:v2",
                   "ports":[
                      {
                         "name":"redis-server",


### PR DESCRIPTION
The image endpoint in guestbook-go for the redis slave controller is outdate and does not work with current examples.

