### PR TITLE
Add volume mount for selenium node chrome deployment

### DIFF
--- a/staging/selenium/selenium-node-chrome-deployment.yaml
+++ b/staging/selenium/selenium-node-chrome-deployment.yaml
@@ -14,11 +14,18 @@ spec:
       labels:
         app: selenium-node-chrome
     spec:
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
       containers:
       - name: selenium-node-chrome
         image: selenium/node-chrome-debug:3.141
         ports:
           - containerPort: 5900
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
         env:
           - name: HUB_HOST
             value: "selenium-hub"


### PR DESCRIPTION
Same code has for `selenium-node-firefox-deployment`
https://github.com/kubernetes/examples/blob/master/staging/selenium/selenium-node-firefox-deployment.yaml#L17

It`s better to add this, according to docker-selenium README
https://github.com/SeleniumHQ/docker-selenium#running-the-images