### PR TITLE
Update an example for pvc in azure files

### DIFF
--- a/staging/volumes/azure_file/azure-pv.yaml
+++ b/staging/volumes/azure_file/azure-pv.yaml
@@ -17,5 +17,5 @@ spec:
     # Replace with correct storage share name
     shareName: k8stest
     # In case the secret is stored in a different namespace
-    #shareNamespace: default
+    #secretNamespace: default
     readOnly: false


### PR DESCRIPTION
Invalid field `shareNamespace` in the comment
The proper field name for access secret in the different namespace is `secretNamespace`