### PR TITLE
Added type NodePort

### DIFF
--- a/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -103,6 +103,8 @@ metadata:
     app: guestbook
     tier: frontend
 spec:
+  # comment or delete the following line if you want to use a LoadBalancer
+  type: NodePort 
   # if your cluster supports it, uncomment the following to automatically create
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer


### PR DESCRIPTION
Ref #368 
Added type NodePort to fix `service default/frontend has no node port` error when applying guestbook-all-in-one.yaml