### PR TITLE
Add missing NodePort to frontend Service

### DIFF
--- a/guestbook/all-in-one/frontend.yaml
+++ b/guestbook/all-in-one/frontend.yaml
@@ -6,6 +6,8 @@ metadata:
     app: guestbook
     tier: frontend
 spec:
+  # comment or delete the following line if you want to use a LoadBalancer
+  type: NodePort 
   # if your cluster supports it, uncomment the following to automatically create
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer


### PR DESCRIPTION
This PR adds missing `NodePort` to `frontend` `Service` in `frontend.yaml`.