### PR TITLE
Update azure_file volume example

### DIFF
--- a/staging/volumes/azure_file/README.md
+++ b/staging/volumes/azure_file/README.md
@@ -31,7 +31,6 @@ In the pod, you need to provide the following information:
 - `secretName`:  the name of the secret that contains both Azure storage account name and key.
 - `shareName`: The share name to be used.
 - `readOnly`: Whether the filesystem is used as readOnly.
-- `secretNamespace`: (optional) The namespace in which the secret was created; `default` is used if not set
 
 Create the secret:
 


### PR DESCRIPTION
Hello Dear people of Kubernetes example.

I was wondering why using the `secretNamespace`property gave me errors, and it look like it's not implemented in the API reference : https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#azurefilevolumesource-v1-core

This is a very simple PR to remove this property for the documentation.