### PR TITLE
mysql-wordpress-pd/OWNERS: remove inactive members from reviewers

### DIFF
--- a/mysql-wordpress-pd/OWNERS
+++ b/mysql-wordpress-pd/OWNERS
@@ -15,7 +15,6 @@ reviewers:
 - eparis
 - mwielgus
 - jlowdermilk
-- david-mcmahon
 - jeffvance
 - jeffmendoza
 - RichieEscarez


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit removes david-mcmahon
from the list of reviewers.

cc @david-mcmahon @mrbobbytables 

/kind cleanup
/assign @idvoretskyi 