### PR TITLE
added comment to clarify that the already-base64-encoded Ceph key must be base64-encoded again when using Kubernetes Secrets, or else use 'stringData' inplace of 'data'

### DIFF
--- a/volumes/cephfs/secret/ceph-secret.yaml
+++ b/volumes/cephfs/secret/ceph-secret.yaml
@@ -3,4 +3,4 @@ kind: Secret
 metadata:
   name: ceph-secret
 data:
-  key: QVFCMTZWMVZvRjVtRXhBQTVrQ1FzN2JCajhWVUxSdzI2Qzg0SEE9PQ==
+  key: QVFCMTZWMVZvRjVtRXhBQTVrQ1FzN2JCajhWVUxSdzI2Qzg0SEE9PQ==  # the base64-encoded string of the already-base64-encoded key `ceph auth get-key` outputs


### PR DESCRIPTION
Some people (myself included) have fallen into [this issue](https://github.com/rook/rook/issues/6053), which I found is caused by forgetting to base64-encode the already-base64-encoded Ceph key.

If I had that comment there earlier today I wouldn't have spent an afternoon debugging this.

More info on my comments on [the issue](https://github.com/rook/rook/issues/6053).