### PR TITLE
guestbook-go: update redis master image

### DIFF
--- a/guestbook-go/redis-master-controller.json
+++ b/guestbook-go/redis-master-controller.json
@@ -25,7 +25,7 @@
             "containers":[
                {
                   "name":"redis-master",
-                  "image":"redis:2.8.23",
+                  "image":"k8s.gcr.io/redis:e2e",
                   "ports":[
                      {
                         "name":"redis-server",


### PR DESCRIPTION
This now matches the image used in the guestbook (non-go) example.
    
Workaround for https://github.com/containerd/containerd/issues/4756
