### PR TITLE
staging/cpu-manager: Remove inactive OWNERS

### DIFF
--- a/staging/cpu-manager/OWNERS
+++ b/staging/cpu-manager/OWNERS
@@ -5,4 +5,5 @@ approvers:
 - vishh
 - ConnorDoyle
 - sjenning
+emeritus_approvers:
 - balajismaniam


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves balajismaniam
from an approver to an emeritus_approver.

/assign @idvoretskyi 