### PR TITLE
[WIP] TeamCity Example

### DIFF
--- a/teamcity/rbac.yaml
+++ b/teamcity/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: teamcity:manage-agents
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "create", "list", "delete"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: teamcity:manage-agents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: teamcity:manage-agents
+subjects:
+  # proper RoleBinding subject depends on your Authentication strategy
+  # use one of examples below
+
+  # if you use OIDC/Certificate auth strategies
+  - kind: User
+    name: teamcity
+
+  # if you use Service account
+  - kind: ServiceAccount
+    name: teamcity


### PR DESCRIPTION

# RBAC resources

The TeamCity user has to be allowed to perform writing operations in the Kubernetes namespace used by TeamCity agents.

- rbac.yaml configures the following privileges for the Kubernetes user role:
  - Pods: `get`, `create`, `list`, `delete`.
  - Deployments: `list`, `get` — if you want to create an agent pod using a deployment configuration.
  - Namespaces: `get`, `list` — to allow TeamCity to suggest the namespaces available on your server.

