### PR TITLE
Update selenium example to selenium 4.0

### DIFF
--- a/staging/selenium/README.md
+++ b/staging/selenium/README.md
@@ -96,17 +96,10 @@ Let's run a quick Selenium job to validate our setup.
 
 #### Setup Python Environment
 
-First, we need to start a python container that we can attach to.
+First, we need to start a python container that we can attach to, then get inside this container.
 
 ```console
-kubectl run selenium-python --image=google/python-hello
-```
-
-Next, we need to get inside this container.
-
-```console
-export PODNAME=`kubectl get pods --selector="run=selenium-python" --output=template --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
-kubectl exec --stdin=true --tty=true $PODNAME bash
+kubectl run selenium-python --tty -i --image=python:slim bash
 ```
 
 Once inside, we need to install the Selenium library
@@ -127,14 +120,17 @@ And paste in the contents of selenium-test.py.
 
 ```python
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 def check_browser(browser):
+  if browser == "CHROME":
+    options = webdriver.ChromeOptions()
+  elif browser == "FIREFOX":
+    options = webdriver.FirefoxOptions()
   driver = webdriver.Remote(
     command_executor='http://selenium-hub:4444/wd/hub',
-    desired_capabilities=getattr(DesiredCapabilities, browser)
+    options=options
   )
-  driver.get("http://google.com")
+  driver.get("http://www.google.com")
   assert "google" in driver.page_source
   driver.quit()
   print("Browser %s checks out!" % browser)
@@ -190,7 +186,6 @@ kubectl delete deployment selenium-node-chrome
 kubectl delete deployment selenium-node-firefox
 kubectl delete deployment selenium-python
 kubectl delete svc selenium-hub
-kubectl delete svc selenium-hub-external
 ```
 
 

--- a/staging/selenium/selenium-hub-deployment.yaml
+++ b/staging/selenium/selenium-hub-deployment.yaml
@@ -16,9 +16,11 @@ spec:
     spec:
       containers:
       - name: selenium-hub
-        image: selenium/hub:3.141
+        image: selenium/hub:4.0
         ports:
           - containerPort: 4444
+          - containerPort: 4443
+          - containerPort: 4442
         resources:
           limits:
             memory: "1000Mi"

--- a/staging/selenium/selenium-hub-svc.yaml
+++ b/staging/selenium/selenium-hub-svc.yaml
@@ -9,6 +9,12 @@ spec:
   - port: 4444
     targetPort: 4444
     name: port0
+  - port: 4443
+    targetPort: 4443
+    name: port1
+  - port: 4442
+    targetPort: 4442
+    name: port2
   selector:
     app: selenium-hub
   type: NodePort

--- a/staging/selenium/selenium-node-chrome-deployment.yaml
+++ b/staging/selenium/selenium-node-chrome-deployment.yaml
@@ -20,17 +20,19 @@ spec:
           medium: Memory
       containers:
       - name: selenium-node-chrome
-        image: selenium/node-chrome-debug:3.141
+        image: selenium/node-chrome:4.0
         ports:
           - containerPort: 5555
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
         env:
-          - name: HUB_HOST
+          - name: SE_EVENT_BUS_HOST
             value: "selenium-hub"
-          - name: HUB_PORT
-            value: "4444"
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: "4443"
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: "4442"
         resources:
           limits:
             memory: "1000Mi"

--- a/staging/selenium/selenium-node-firefox-deployment.yaml
+++ b/staging/selenium/selenium-node-firefox-deployment.yaml
@@ -20,17 +20,19 @@ spec:
           medium: Memory
       containers:
       - name: selenium-node-firefox
-        image: selenium/node-firefox-debug:3.141
+        image: selenium/node-firefox:4.0
         ports:
-          - containerPort: 5900
+          - containerPort: 5555
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
         env:
-          - name: HUB_HOST
+          - name: SE_EVENT_BUS_HOST
             value: "selenium-hub"
-          - name: HUB_PORT
-            value: "4444"
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: "4443"
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: "4442"
         resources:
           limits:
             memory: "1000Mi"

--- a/staging/selenium/selenium-test.py
+++ b/staging/selenium/selenium-test.py
@@ -15,14 +15,17 @@
 # limitations under the License.
 
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 def check_browser(browser):
+  if browser == "CHROME":
+    options = webdriver.ChromeOptions()
+  elif browser == "FIREFOX":
+    options = webdriver.FirefoxOptions()
   driver = webdriver.Remote(
     command_executor='http://selenium-hub:4444/wd/hub',
-    desired_capabilities=getattr(DesiredCapabilities, browser)
+    options=options
   )
-  driver.get("http://google.com")
+  driver.get("http://www.google.com")
   assert "google" in driver.page_source
   driver.quit()
   print("Browser %s checks out!" % browser)


### PR DESCRIPTION
The newest major version of Selenium 4.0 was released, and some specifications had been changed. 
Updating the example to follow the latest version.
Also fix some out-of-date procedures in the example’s README.

These changes are follow in the latest Selenium README: https://github.com/SeleniumHQ/docker-selenium
