### PR TITLE
Use NFS server v4.2 in nfs-pv example

### DIFF
--- a/staging/volumes/nfs/nfs-pv.yaml
+++ b/staging/volumes/nfs/nfs-pv.yaml
@@ -10,3 +10,5 @@ spec:
   nfs:
     server: nfs-server.default.svc.cluster.local
     path: "/"
+  mountOptions:
+    - nfsvers=4.2


### PR DESCRIPTION
We had problems with running the default v4 version, limit on connection pool etc, seems like 4.2 would be a better default