### PR TITLE
Update GlusterFS docs URL README.md

### DIFF
--- a/volumes/glusterfs/README.md
+++ b/volumes/glusterfs/README.md
@@ -13,7 +13,7 @@ have a working GlusterFS volume ready to use in the containers.
 * Create a GlusterFS volume
 * If you are not using hyperkube, you may need to install the GlusterFS client
   package on the Kubernetes nodes
-  ([Guide](http://gluster.readthedocs.io/en/latest/Administrator%20Guide/))
+  ([Guide](https://docs.gluster.org/en/latest/Administrator-Guide/Setting-Up-Clients/))
 
 #### Create endpoints
 


### PR DESCRIPTION
The old URL `gluster.readthedocs.io/en/latest/Administrator%20Guide/` is returning 404 as GlusterFS seems using the `https://docs.gluster.org`, this PR is used to change the URL to the correct one.
![Screenshot from 2021-11-21 21-21-23](https://user-images.githubusercontent.com/24852034/142763565-fcb5dc87-a3d2-437f-81f9-25272467e438.png)
