### PR TITLE
pvc nfs example : add "volumeName" to nfs-pvc to connect it to nfs-pv

### DIFF
--- a/staging/volumes/nfs/nfs-pvc.yaml
+++ b/staging/volumes/nfs/nfs-pvc.yaml
@@ -9,3 +9,4 @@ spec:
   resources:
     requests:
       storage: 1Mi
+  volumeName: nfs


### PR DESCRIPTION
it is very weird that there is no connection between nfs-pv and nfs-pvc
 Where I copy this example it works, but when I used it with multiple PVs and PVVs, this is not working -PVC is bounded to a random PVC

I wondering if adding "volumeName" to PVC  is enough or we need also add claimRef to PV
