### PR TITLE
Use redis-replica instead of redis-slave in GUI

### DIFF
--- a/guestbook/php-redis/guestbook.php
+++ b/guestbook/php-redis/guestbook.php
@@ -23,7 +23,7 @@ if (isset($_GET['cmd']) === true) {
     $client->set($_GET['key'], $_GET['value']);
     print('{"message": "Updated"}');
   } else {
-    $host = 'redis-slave';
+    $host = 'redis-replica';
     if (getenv('GET_HOSTS_FROM') == 'env') {
       $host = getenv('REDIS_SLAVE_SERVICE_HOST');
     }


### PR DESCRIPTION
With change in the name of services for redis replicas, the php code needs update to point to the right pod. Without the fix the guestbook app is broken.