### PR TITLE
Update owners to match sig-apps leads

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,13 @@
 
 reviewers:
   - idvoretskyi
+  - janetkuo
+  - kow3ns
   - sebgoa
+  - soltysh
 approvers:
   - idvoretskyi
+  - janetkuo
+  - kow3ns
   - sebgoa
+  - soltysh


### PR DESCRIPTION
To match what we have stated in https://github.com/kubernetes/community/tree/master/sig-apps#examples this PR updates the OWNERS with all sig-apps leads.

/assign @sebgoa 