### PR TITLE
delete duplicated selector in minio-statefulset

### DIFF
--- a/staging/storage/minio/minio-distributed-statefulset.yaml
+++ b/staging/storage/minio/minio-distributed-statefulset.yaml
@@ -10,9 +10,6 @@ spec:
       app: minio
   serviceName: minio
   replicas: 4
-  selector:
-    matchLabels:
-      app: minio
   template:
     metadata:
       labels:


### PR DESCRIPTION
Selector in `minio-distributed-statefulset.yaml` duplication caused error, so this pr aims to delete duplicated selector.