### PR TITLE
[nfs-example] Use Deployments instead of ReplicationController

### DIFF
--- a/staging/volumes/nfs/nfs-busybox-deployment.yaml
+++ b/staging/volumes/nfs/nfs-busybox-deployment.yaml
@@ -1,14 +1,15 @@
 # This mounts the nfs volume claim into /mnt and continuously
 # overwrites /mnt/index.html with the time and hostname of the pod.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: nfs-busybox
 spec:
   replicas: 2
   selector:
-    name: nfs-busybox
+    matchLabels:
+      name: nfs-busybox
   template:
     metadata:
       labels:

--- a/staging/volumes/nfs/nfs-server-deployment.yaml
+++ b/staging/volumes/nfs/nfs-server-deployment.yaml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: nfs-server
 spec:
   replicas: 1
   selector:
-    role: nfs-server
+    matchLabels:
+      role: nfs-server
   template:
     metadata:
       labels:

--- a/staging/volumes/nfs/nfs-web-deployment.yaml
+++ b/staging/volumes/nfs/nfs-web-deployment.yaml
@@ -1,14 +1,15 @@
 # This pod mounts the nfs volume claim into /usr/share/nginx/html and
 # serves a simple web page.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: nfs-web
 spec:
   replicas: 2
   selector:
-    role: web-frontend
+    matchLabels:
+      role: web-frontend
   template:
     metadata:
       labels:


### PR DESCRIPTION
According to the official kubernetes documentation it is recommended to use a Deployment instead of a ReplicationController to set up replication
https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/