### PR TITLE
Align subject in the key pair to be the same as the documentation

### DIFF
--- a/staging/https-nginx/Makefile
+++ b/staging/https-nginx/Makefile
@@ -22,7 +22,7 @@ SECRET = /tmp/secret.json
 
 keys:
 	# The CName used here is specific to the service specified in nginx-app.yaml.
-	openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $(KEY) -out $(CERT) -subj "/CN=nginxsvc/O=nginxsvc"
+	openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $(KEY) -out $(CERT) -subj "/CN=my-nginx/O=my-nginx"
 
 container:
 	docker build --pull -t $(PREFIX):$(TAG) .


### PR DESCRIPTION
The https-nginx/Makefile refers to subject as "/CN=nginxsvc/O=nginxsvc"
while the documentation at the "Securing the Service" section
expects it to be "/CN=my-nginx/O=my-nginx"

So if we run using the Makefile instead of the manual process
doumented below, the service creation fails.

This PR aligns the subject in the openssl command with the documentation.

It addresses https://github.com/kubernetes/website/issues/34322

Signed-off-by: Eduardo Patrocinio epatro@gmail.com