### PR TITLE
Mention GlusterFS deprecation in the examples guide.

### DIFF
--- a/volumes/glusterfs/README.md
+++ b/volumes/glusterfs/README.md
@@ -1,5 +1,10 @@
 ## GlusterFS
 
+
+NOTE: GlusterFS in-tree storage driver ( `kubernetes.io/glusterfs`) which was
+deprecated in kubernetes 1.25 release is removed entirely  in `v1.26`. Volumes
+must be migrated to an alternate storage solution before upgrading to `v1.26`.
+
 [GlusterFS](http://www.gluster.org) is an open source scale-out filesystem.
 These examples provide information about how to allow containers use GlusterFS
 volumes.


### PR DESCRIPTION
Considering GlusterFS in-tree storage driver has been deprecated in 1.25 and then removed in 1.26, it has to be notified to the users who are referring the example yamls here. Eventually we will remove the example yamls while these kubernetes versions go unsupported.