### PR TITLE
Mention Ceph RBD and CephFS deprecation in the user doc to notify the users.

### DIFF
--- a/volumes/cephfs/README.md
+++ b/volumes/cephfs/README.md
@@ -1,5 +1,11 @@
 # How to Use it?
 
+NOTE: CephFS storage driver ( `kubernetes.io/cephfs`) has been
+deprecated in kubernetes 1.28 release and will be in removed in subsequent
+releases. The CSI driver for CephFS (https://github.com/ceph/ceph-csi)
+is available for long time now which can be an alternative option for the
+users want to use CephFS volumes in their clusters.
+
 Install Ceph on the Kubernetes host. For example, on Fedora 21
 
     # yum -y install ceph

--- a/volumes/rbd/README.md
+++ b/volumes/rbd/README.md
@@ -1,5 +1,11 @@
 # How to Use it?
 
+NOTE: Ceph RBD in-tree storage driver ( `kubernetes.io/rbd`) has been
+deprecated in kubernetes 1.28 release and will be in removed in subsequent
+releases. The CSI driver for Ceph RBD (https://github.com/ceph/ceph-csi)
+is available for long time now which can be an alternative option for the
+users want to use Ceph RBD volumes in their clusters.
+
 Install Ceph on the Kubernetes host. For example, on Fedora 21
 
     # yum -y install ceph-common


### PR DESCRIPTION
The Ceph RBD and CephFS intree storage driver is getting deprecated in kubernetes release 1.28 and users have to be notified about the same.