### PR TITLE
issue #506--->fixed the redis issue

### DIFF
--- a/guestbook-go/Dockerfile
+++ b/guestbook-go/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.10.0
 RUN go get github.com/codegangsta/negroni \
            github.com/gorilla/mux \
-           github.com/xyproto/simpleredis
+           github.com/xyproto/simpleredis/v2
 WORKDIR /app
 ADD ./main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -o main .

--- a/guestbook-go/main.go
+++ b/guestbook-go/main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
-	"github.com/xyproto/simpleredis"
+	"github.com/xyproto/simpleredis/v2"
 )
 
 var (

--- a/guestbook-go/redis-master-controller.yaml
+++ b/guestbook-go/redis-master-controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: registry.k8s.io/redis:e2e
+        image: redis
         ports:
         - name: redis-server
           containerPort: 6379

--- a/guestbook-go/redis-replica-controller.yaml
+++ b/guestbook-go/redis-replica-controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: redis-replica
-        image: k8s.gcr.io/redis-slave:v2
+        image: registry.k8s.io/redis-slave:v2
         ports:
         - name: redis-server
           containerPort: 6379

--- a/guestbook-go/redis-replica-controller.yaml
+++ b/guestbook-go/redis-replica-controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: redis-replica
-        image: registry.k8s.io/redis-slave:v2
+        image: k8s.gcr.io/redis-slave:v2
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
While creating docker image of guestbook go, We encountered an error regarding the simpleredis reposity.
Modified and changed it to the v2 of repo. The DockerImage is created successfully now.
Also changes the redis image in redis master controller and replica controller yaml file.
The issue should have been resolved