### PR TITLE
Fix Dockerfile for Guestbook Application Build

### DIFF
--- a/guestbook-go/Dockerfile
+++ b/guestbook-go/Dockerfile
@@ -12,17 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.0
+FROM golang:1.18 AS builder
+
+
+WORKDIR /app
+
+
+RUN go mod init temp-module || true
 RUN go get github.com/codegangsta/negroni \
            github.com/gorilla/mux \
            github.com/xyproto/simpleredis/v2
-WORKDIR /app
-ADD ./main.go .
+
+
+COPY ./main.go .
+
+
 RUN CGO_ENABLED=0 GOOS=linux go build -o main .
+
 
 FROM scratch
 WORKDIR /app
-COPY --from=0 /app/main .
+COPY --from=builder /app/main .
 COPY ./public/index.html public/index.html
 COPY ./public/script.js public/script.js
 COPY ./public/style.css public/style.css


### PR DESCRIPTION
This PR updates the Dockerfile to resolve build errors caused by outdated dependencies.

**Issue Addressed:**
- The previous Dockerfile using Go 1.10.0 failed to build due to incompatibilities with newer Go packages, specifically the `undefined: any` error in `github.com/gorilla/mux`.

**Changes Made:**
- Upgraded to Go 1.18 to ensure compatibility with the latest dependencies.
- Added Go module initialization to handle package dependencies correctly.

**Impact:**
- Resolves build issues and ensures the Dockerfile works with the latest Go ecosystem.
- Improves the build process and compatibility for the guestbook application.

This update addresses the build error and aligns the Dockerfile with modern Go practices, ensuring a smoother development and deployment experience.

Issue - guestbook go build issue #540