### PR TITLE
Bump example-dns-backend to python3

### DIFF
--- a/staging/cluster-dns/dns-backend-rc.yaml
+++ b/staging/cluster-dns/dns-backend-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: dns-backend
-          image: registry.k8s.io/example-dns-backend:v1
+          image: registry.k8s.io/example-dns-backend:v2
           ports:
             - name: backend-port
               containerPort: 8000

--- a/staging/cluster-dns/images/backend/Dockerfile
+++ b/staging/cluster-dns/images/backend/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:2.7-slim
+FROM python:3-slim
 
 COPY . /dns-backend
 WORKDIR /dns-backend

--- a/staging/cluster-dns/images/backend/Makefile
+++ b/staging/cluster-dns/images/backend/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = v1
+TAG = v2
 PREFIX = staging-k8s.gcr.io
 IMAGE = example-dns-backend
 


### PR DESCRIPTION
2.7 is dated, so let's update it

More importantly looking at:
https://explore.ggcr.dev/?image=registry.k8s.io%2Fexample-dns-backend:v1

The image is using schema version 1 which has been already removed or will be in [containerd 2.0](https://github.com/containerd/containerd/blob/15dd956915db180f189f9cb6338529e62b7a64fd/RELEASES.md?plain=1#L452-L453)
```
{
"schemaVersion": 1,
"name": "google_containers/example-dns-backend",
"architecture": "amd64",
"fsLayers": [
```

So let's build a v2 version of this image