### PR TITLE
Guestbook: Update php-redis image tag to v5

### DIFF
--- a/guestbook/all-in-one/frontend.yaml
+++ b/guestbook/all-in-one/frontend.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/guestbook/frontend-deployment.yaml
+++ b/guestbook/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v5
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Fixes: #550 

The image `gcr.io/google-samples/gb-frontend` with tag `v4` is not available in the registry. Updating it to `v5`.