### PR TITLE
Update redis-master-controller ReplicationController to Deployment (modern Kubernetes API)

### DIFF
--- a/web/guestbook-go/redis-master-controller.yaml
+++ b/web/guestbook-go/redis-master-controller.yaml
@@ -1,15 +1,16 @@
-kind: ReplicationController
-apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment 
 metadata:
-  name: redis-master
-  labels:
+ name: redis-master
+ labels:
     app: redis
     role: master
 spec:
   replicas: 1
   selector:
-    app: redis
-    role: master
+    matchLabels:
+      app: redis
+      role: master
   template:
     metadata:
       labels:
@@ -18,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: redis
+        image: redis:7.2
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
This PR modernizes the Redis master controller example by replacing the deprecated ReplicationController with Deployment. Deployments provide better control, rolling updates and self healing for pods. 

Changes Made: 
Updated "kind" and "apiVersion" 
Added selector.matchLabels as required by Deployment 
Verified locally on kind cluster — Deployment and Pod created successfully.